### PR TITLE
feat: add filtering option to display only loaded packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
         "command": "positron-r-package-manager.searchPackages",
         "title": "%search.packages%",
         "icon": "$(search)"
+      },
+      {
+        "command": "positron-r-package-manager.filterLoadedPackages",
+        "title": "Filter loaded packages",
+        "icon": "$(filter)"
       }
     ],
     "viewsContainers": {
@@ -112,6 +117,12 @@
           "command": "positron-r-package-manager.searchPackages",
           "when": "view == rPackageView",
           "group": "navigation@99"
+        },
+        {
+          "command": "positron-r-package-manager.filterLoadedPackages",
+          "when": "view == rPackageView",
+          "group": "navigation@3",
+          "toggle": true
         },
         {
           "command": "positron-r-package-manager.refreshPackages",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       },
       {
         "command": "positron-r-package-manager.filterLoadedPackages",
-        "title": "Filter loaded packages",
+        "title": "%filterLoadedPackages%",
         "icon": "$(filter)"
       }
     ],

--- a/package.nls.json
+++ b/package.nls.json
@@ -10,5 +10,5 @@
     "search.packages": "R: Search for installed packages",
     "packages": "Packages",
     "showRIcon": "Show an R icon next to package names",
-    "filterLoadedPackages": "Show loaded packages"
+    "filterLoadedPackages": "R: Show loaded packages"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,5 +9,6 @@
     "refresh.packages": "R: Refresh package information",
     "search.packages": "R: Search for installed packages",
     "packages": "Packages",
-    "showRIcon": "Show an R icon next to package names"
+    "showRIcon": "Show an R icon next to package names",
+    "filterLoadedPackages": "Show loaded packages"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -10,5 +10,5 @@
     "search.packages": "R: 搜索已安装的包",
     "packages": "包",
     "showRIcon": "在包名称前显示R图标",
-    "filterLoadedPackages": "显示已加载的包"
+    "filterLoadedPackages": "R: 显示已加载的包"
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -9,5 +9,6 @@
     "refresh.packages": "R: 刷新包信息",
     "search.packages": "R: 搜索已安装的包",
     "packages": "包",
-    "showRIcon": "在包名称前显示R图标"
+    "showRIcon": "在包名称前显示R图标",
+    "filterLoadedPackages": "显示已加载的包"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,9 +89,14 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('positron-r-package-manager.uninstallPackage', (item: RPackageItem | undefined) => {
 			uninstallPackage(item, sidebarProvider);
 		}),
+
 		// update packages
 		vscode.commands.registerCommand('positron-r-package-manager.updatePackages', () => {
 			updatePackages(sidebarProvider);
+		}),
+
+		vscode.commands.registerCommand('positron-r-package-manager.filterLoadedPackages', () => {
+			sidebarProvider.toggleShowOnlyLoadedPackages();
 		})
 	);
 }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -16,6 +16,7 @@ export interface RPackageInfo {
 
 export class SidebarProvider implements vscode.TreeDataProvider<RPackageItem> {
     private filterText: string = '';
+    private showOnlyLoadedPackages: boolean = false;
     private _onDidChangeTreeData: vscode.EventEmitter<RPackageItem | undefined | void> = new vscode.EventEmitter();
     readonly onDidChangeTreeData: vscode.Event<RPackageItem | undefined | void> = this._onDidChangeTreeData.event;
 
@@ -63,6 +64,10 @@ export class SidebarProvider implements vscode.TreeDataProvider<RPackageItem> {
             });
 
             filtered = matches.map(m => m.pkg);
+        }
+
+        if (this.showOnlyLoadedPackages) {
+            filtered = filtered.filter(pkg => pkg.loaded);
         }
 
         if (filtered.length === 0) {
@@ -123,6 +128,11 @@ export class SidebarProvider implements vscode.TreeDataProvider<RPackageItem> {
      */
     getPackages(): RPackageInfo[] {
         return this.packages;
+    }
+
+    toggleShowOnlyLoadedPackages() {
+        this.showOnlyLoadedPackages = !this.showOnlyLoadedPackages;
+        this._onDidChangeTreeData.fire(); // Refresh the tree
     }
 }
 


### PR DESCRIPTION
### Changes: 

- Added a filtering option through a new button to display only loaded packages.

The enhances usability by allowing users to doesn't parse a long list to see which package is load in the project.